### PR TITLE
removed all the unsafe's and most of the unwraps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 num-traits = "0.2"
 num_cpus = "1.0"
+crossbeam = "0.8.0"
 
 [profile.dev]
 opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,167 +1,179 @@
 // implementation of common parallel algorithms in rust (only 1 currently)
 // - parallel prefix sum
 
-use std::thread;
-use std::ops::AddAssign;
-
-extern crate num_traits;
+use num_cpus;
 use num_traits::identities::Zero;
-
-extern crate num_cpus;
+use std::{ops::AddAssign};
 
 const SEQUENTIAL_THRESHOLD: usize = 16;
 
 // struct to hold important information for the parallel prefix sum operations
-struct PrefixTree<T> {
-    low: usize,
-    high: usize,
+struct PrefixTree<T>
+where
+    for<'t> T: AddAssign<&'t T>,
+    T: Send,
+    T: Zero,
+{
     sum: T,
     from_left: T,
     left: Option<Box<PrefixTree<T>>>,
     right: Option<Box<PrefixTree<T>>>,
 }
 
+impl<T> PrefixTree<T>
+where
+    for<'t> T: AddAssign<&'t T>,
+    T: Send,
+    T: Zero,
+{
+    pub fn default() -> Self {
+        PrefixTree::<T> {
+            sum: T::zero(),
+            from_left: T::zero(),
+            left: None,
+            right: None,
+        }
+    }
+}
+
 // runs a parallel prefix sum in place on this mutable slice
 // type of indices of slide must implement Zero and AddAssign
-pub fn parallel_prefix_sum<T: Zero>(array: &mut[T]) where for<'t> T: AddAssign<&'t T> {
+pub fn parallel_prefix_sum<T>(array: &mut [T])
+where
+    for<'t> T: AddAssign<&'t T>,
+    T: Send,
+    T: Zero,
+{
     if array.len() > 0 {
-	let cores: usize = num_cpus::get();
-	
-	let array_ptr: *mut T = array.as_mut_ptr();
-	
-	let mut tree: PrefixTree<T> = PrefixTree::<T>{low: 0, high: array.len(), sum: T::zero(), from_left: T::zero(), left: None, right: None};
-	
-	// collect sums and build prefix tree
-	pps_sum(array_ptr, &mut tree, cores);
-	
-	// finalize and distribute sums from prefix tree
-	pps_distribute(array_ptr, &mut tree);
+        let cores: usize = num_cpus::get();
+
+        let mut tree = PrefixTree::<T>::default();
+
+        // collect sums and build prefix tree
+        pps_sum(array, &mut tree, cores);
+
+        // finalize and distribute sums from prefix tree
+        pps_distribute(array, &mut tree);
     }
 }
 
 // collect sums and build prefix tree from the array
-fn pps_sum<T: Zero>(array_ptr: *mut T, tree_ptr: &mut PrefixTree<T>, cores: usize) where for<'t> T: AddAssign<&'t T> {
-    let low: usize = tree_ptr.low;
-    let high: usize = tree_ptr.high;
-
-    if cores == 1 || high - low <= SEQUENTIAL_THRESHOLD {
-	// sequential
-
-	unsafe {
-	    for i in low..high {
-		tree_ptr.sum += &*array_ptr.add(i);
-	    }
-	}
+fn pps_sum<T>(array: &mut [T], tree: &mut PrefixTree<T>, cores: usize)
+where
+    for<'t> T: AddAssign<&'t T>,
+    T: Send,
+    T: Zero,
+{
+    if cores == 1 || array.len() <= SEQUENTIAL_THRESHOLD {
+        // sequential
+        for v in array {
+            tree.sum += v
+        }
     } else {
-	// parallel
+        // parallel
+        let mut left = PrefixTree::<T>::default();
+        let mut right = PrefixTree::<T>::default();
 
-	let mid: usize = low + (high - low)/2;
+        let left_cores: usize = cores / 2;
+        let right_cores: usize = cores - left_cores;
 
-	let left: PrefixTree<T> = PrefixTree::<T>{low, high: mid, sum: T::zero(), from_left: T::zero(), left: None, right: None};
-	let right: PrefixTree<T> = PrefixTree::<T>{low: mid, high, sum: T::zero(), from_left: T::zero(), left: None, right: None};
-	tree_ptr.left = Some(Box::new(left));
-	tree_ptr.right = Some(Box::new(right));
+        // have to split, since each thread requires unique access...
+        let (left_arr, right_arr) = array.split_at_mut(array.len() / 2);
+        crossbeam::scope(|scope| {
+            scope.spawn(|_| {
+                pps_sum(left_arr, &mut left, left_cores);
+            });
+            pps_sum(right_arr, &mut right, right_cores);
+        })
+        .unwrap(); // probably should handle this error somehow...
 
-	let left_ptr: &mut PrefixTree<T> = &mut**(&mut tree_ptr.left).as_mut().unwrap();
-	let right_ptr: &mut PrefixTree<T> = &mut**(&mut tree_ptr.right).as_mut().unwrap();
-
-	let left_cores: usize = cores/2;
-	let right_cores: usize = cores - left_cores;
-
-	let array_disguise: usize = array_ptr as usize;
-	let left_disguise: usize = left_ptr as *mut PrefixTree<T> as usize;
-
-	let handle: thread::JoinHandle<()>;
-	unsafe {
-	    handle = thread::spawn(move || {
-		pps_sum(array_disguise as *mut T, (left_disguise as *mut PrefixTree<T>).as_mut().unwrap(), left_cores);
-	    });
-	}
-	pps_sum(array_ptr, right_ptr, right_cores);
-	handle.join().unwrap();
-
-	tree_ptr.sum += &left_ptr.sum;
-	tree_ptr.sum += &right_ptr.sum;
+        tree.sum += &left.sum;
+        tree.sum += &right.sum;
+        tree.left = Some(Box::new(left));
+        tree.right = Some(Box::new(right));
     }
 }
 
 // finalize and distribute sums from prefix tree to the array
-fn pps_distribute<T>(array_ptr: *mut T, tree_ptr: &mut PrefixTree<T>) where for<'t> T: AddAssign<&'t T> {
-    if tree_ptr.left.is_none() {
-	// sequential
-	
-	let low: usize = tree_ptr.low;
-	let high: usize = tree_ptr.high;
-	
-	let from_left: &T = &tree_ptr.from_left;
+fn pps_distribute<T>(array: &mut [T], tree: &mut PrefixTree<T>)
+where
+    for<'t> T: AddAssign<&'t T>,
+    T: Send,
+    T: Zero,
+{
+    match (tree.left.as_mut(), tree.right.as_mut()) {
+        (Some(left), Some(right)) => {
+            left.from_left += &tree.from_left;
+            right.from_left += &tree.from_left;
+            right.from_left += &left.sum;
 
-	unsafe {
-	    for i in low + 1..high {
-		*array_ptr.add(i) += &*array_ptr.add(i - 1);
-		*array_ptr.add(i - 1) += from_left;
-	    }
-	    *array_ptr.add(high - 1) += from_left;
-	}
-    } else {
-	// parallel
-	
-	let left_ptr: &mut PrefixTree<T> = &mut**(&mut tree_ptr.left).as_mut().unwrap();
-	let right_ptr: &mut PrefixTree<T> = &mut**(&mut tree_ptr.right).as_mut().unwrap();
-	
-	left_ptr.from_left += &tree_ptr.from_left;
-	right_ptr.from_left += &tree_ptr.from_left;
-	right_ptr.from_left += &left_ptr.sum;
-	
-	let array_disguise: usize = array_ptr as usize;
-	let left_disguise: usize = left_ptr as *mut PrefixTree<T> as usize;
-
-	let handle: thread::JoinHandle<()>;
-	unsafe {
-	    handle = thread::spawn(move || {
-		pps_distribute(array_disguise as *mut T, (left_disguise as *mut PrefixTree<T>).as_mut().unwrap());
-	    });
-	}
-	pps_distribute(array_ptr, right_ptr);
-	handle.join().unwrap();
+            let (left_arr, right_arr) = array.split_at_mut(array.len() / 2);
+            crossbeam::scope(|scope| {
+                scope.spawn(|_| pps_distribute(left_arr, left));
+                pps_distribute(right_arr, right);
+            })
+            .unwrap(); // probably should handle this error somehow...
+        }
+        _ => {
+            let from_left: &T = &tree.from_left;
+            for i in 1..array.len() {
+                let (a, b) = array.split_at_mut(i);
+                b[0] += &a[i - 1];
+                array[i - 1] += from_left;
+            }
+            array[array.len() - 1] += from_left;
+        }
     }
 }
 
 // run some tests
 #[cfg(test)]
 mod tests {
-    use std::time::{Instant};
+    use crate::parallel_prefix_sum;
+    use std::time::Instant;
 
     const N: usize = 10000000;
+
+    #[test]
+    fn test_parallel_prefix_sum_small() {
+        let mut arr = [1; 20];
+        parallel_prefix_sum::<u128>(&mut arr);
+        let mut expected = [0; 20];
+        for i in 0..20 {
+            expected[i] = (i as u128) + 1;
+        }
+        assert_eq!(expected, arr);
+    }
 
     // test parallel prefix sum algorithm
     #[test]
     fn test_parallel_prefix_sum() {
-	// generate some random data
-	let mut par: Vec<u128> = Vec::new();
-	for i in 0..N {
-	    let i: u128 = i as u128;
-	    par.push(64+i*i-(8*i) + 5);
-	}
-	let mut seq: Vec<u128> = par.clone();
+        // generate some random data
+        let mut par: Vec<u128> = Vec::new();
+        for i in 0..N {
+            let i: u128 = i as u128;
+            par.push(64 + i * i - (8 * i) + 5);
+        }
+        let mut seq: Vec<u128> = par.clone();
 
-	// time parallel algorithm
-	let start_par = Instant::now();
-	crate::parallel_prefix_sum::<u128>(&mut par[..]);
-	let dur_par = start_par.elapsed();
+        // time parallel algorithm
+        let start_par = Instant::now();
+        parallel_prefix_sum::<u128>(&mut par[..]);
+        let dur_par = start_par.elapsed();
 
-	// time sequential algorithm
-	let start_seq = Instant::now();
-	for i in 1..seq.len() {
-	    seq[i] += seq[i - 1];
-	}
-	let dur_seq = start_seq.elapsed();
-	
-	// check integrity of results
-	for i in 0..par.len() {
-	    assert_eq!(seq[i], par[i]);
-	}
+        // time sequential algorithm
+        let start_seq = Instant::now();
+        for i in 1..seq.len() {
+            seq[i] += seq[i - 1];
+        }
+        let dur_seq = start_seq.elapsed();
 
-	// print results
-	println!("parallel = {:?}, sequential = {:?}", dur_par, dur_seq);
+        // check integrity of results
+        for i in 0..par.len() {
+            assert_eq!(seq[i], par[i]);
+        }
+
+        // print results
+        println!("parallel = {:?}, sequential = {:?}", dur_par, dur_seq);
     }
 }


### PR DESCRIPTION
This PR removes all the `unsafe` and most of the `unwrap()`s. It adds `crossbeam` as a dependency so that we can use scoped threads, which allows us to pass references into threads. It requires `T` to be `Send` for thread safety reasons. It also adds one small and quick test case to check the parallel prefix sum.

