### PR TITLE
made modules public, renamed variables, added tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,5 @@
 
 const SEQUENTIAL_THRESHOLD: usize = 256;
 
-mod prefix;
-mod pack;
+pub mod pack;
+pub mod prefix;

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -1,6 +1,6 @@
+use super::SEQUENTIAL_THRESHOLD;
 use num_cpus;
 use std::ops::AddAssign;
-use super::SEQUENTIAL_THRESHOLD;
 
 // parallel prefix sum (in place)
 pub fn parallel_prefix_sum<T: Send>(array: &mut [T])
@@ -11,7 +11,7 @@ where
 }
 
 // parallel prefix sum (in place)
-pub fn parallel_prefix_sum_tune<T: Send>(array: &mut [T], cores: usize, threshold: usize)
+pub fn parallel_prefix_sum_tune<T: Send>(array: &mut [T], threads: usize, seq_threshold: usize)
 where
     for<'t> T: AddAssign<&'t T>,
 {
@@ -20,8 +20,8 @@ where
         &|a: &mut T, b: &T| {
             *a += b;
         },
-        cores,
-        threshold,
+        threads,
+        seq_threshold,
     );
 }
 
@@ -34,32 +34,38 @@ pub fn parallel_prefix<T: Send, F: Fn(&mut T, &T) + Sync>(array: &mut [T], accum
 pub fn parallel_prefix_tune<T: Send, F: Fn(&mut T, &T) + Sync>(
     array: &mut [T],
     accumulate_fn: &F,
-    mut cores: usize,
-    mut threshold: usize,
+    threads: usize,
+    seq_threshold: usize,
 ) {
-    if cores == 0 {
-	cores = 1;
+    if threads == 0 {
+        panic!("threads cannot be zero!");
     }
-    if threshold == 0 {
-	threshold = 1;
+    if seq_threshold == 0 {
+        panic!("seq_threshold cannot be zero!");
     }
-    
+
     // collect and build sums
-    parallel_prefix_accumulate(array, accumulate_fn, cores, threshold);
+    parallel_prefix_accumulate(array, accumulate_fn, threads, seq_threshold);
 
     // finalize and distribute sums
     let len: usize = array.len() - 1;
-    parallel_prefix_distribute(&mut array[..len], accumulate_fn, cores, threshold, true);
+    parallel_prefix_distribute(
+        &mut array[..len],
+        accumulate_fn,
+        threads,
+        seq_threshold,
+        true,
+    );
 }
 
 // collect and build sums
 fn parallel_prefix_accumulate<T: Send, F: Fn(&mut T, &T) + Sync>(
     array: &mut [T],
     accumulate_fn: &F,
-    cores: usize,
-    threshold: usize,
+    threads: usize,
+    seq_threshold: usize,
 ) {
-    if cores == 1 || array.len() <= threshold {
+    if threads == 1 || array.len() <= seq_threshold {
         // sequential
         let (array, end) = array.split_at_mut(array.len() - 1);
         let sum: &mut T = &mut end[0];
@@ -68,19 +74,19 @@ fn parallel_prefix_accumulate<T: Send, F: Fn(&mut T, &T) + Sync>(
         }
     } else {
         // parallel
-        let left_cores: usize = cores / 2;
-        let right_cores: usize = cores - left_cores;
+        let left_threads: usize = threads / 2;
+        let right_threads: usize = threads - left_threads;
 
         // have to split, since each thread requires unique access...
         let (left, right) = array.split_at_mut(array.len() / 2);
 
         crossbeam::scope(|scope| {
             scope.spawn(|_| {
-                parallel_prefix_accumulate(left, accumulate_fn, left_cores, threshold);
+                parallel_prefix_accumulate(left, accumulate_fn, left_threads, seq_threshold);
             });
-            parallel_prefix_accumulate(right, accumulate_fn, right_cores, threshold);
+            parallel_prefix_accumulate(right, accumulate_fn, right_threads, seq_threshold);
         })
-        .unwrap(); // probably should handle this error somehow...
+        .unwrap();
 
         accumulate_fn(&mut right[right.len() - 1], &left[left.len() - 1]); // sum accumulation
     }
@@ -90,11 +96,11 @@ fn parallel_prefix_accumulate<T: Send, F: Fn(&mut T, &T) + Sync>(
 fn parallel_prefix_distribute<T: Send, F: Fn(&mut T, &T) + Sync>(
     array: &mut [T],
     accumulate_fn: &F,
-    cores: usize,
-    threshold: usize,
+    threads: usize,
+    seq_threshold: usize,
     start: bool,
 ) {
-    if cores == 1 || array.len() <= threshold {
+    if threads == 1 || array.len() <= seq_threshold {
         // sequential
         for i in 1..array.len() {
             let (prev, now) = array.split_at_mut(i);
@@ -102,8 +108,8 @@ fn parallel_prefix_distribute<T: Send, F: Fn(&mut T, &T) + Sync>(
         }
     } else {
         // parallel
-        let left_cores: usize = cores / 2;
-        let right_cores: usize = cores - left_cores;
+        let left_threads: usize = threads / 2;
+        let right_threads: usize = threads - left_threads;
 
         let left;
         let right;
@@ -122,9 +128,9 @@ fn parallel_prefix_distribute<T: Send, F: Fn(&mut T, &T) + Sync>(
 
         crossbeam::scope(|scope| {
             scope.spawn(|_| {
-                parallel_prefix_distribute(left, accumulate_fn, left_cores, threshold, start);
+                parallel_prefix_distribute(left, accumulate_fn, left_threads, seq_threshold, start);
             });
-            parallel_prefix_distribute(right, accumulate_fn, right_cores, threshold, false);
+            parallel_prefix_distribute(right, accumulate_fn, right_threads, seq_threshold, false);
         })
         .unwrap();
     }
@@ -133,24 +139,11 @@ fn parallel_prefix_distribute<T: Send, F: Fn(&mut T, &T) + Sync>(
 // run some tests
 #[cfg(test)]
 mod tests {
-    use crate::prefix::parallel_prefix_sum;
+    use crate::prefix::*;
     use std::time::Instant;
 
     const N: usize = 10000000;
-    const K: usize = 20;
-
-    #[test]
-    fn test_parallel_prefix_sum_small() {
-        let mut arr = [1; K];
-        parallel_prefix_sum::<u128>(&mut arr);
-        let mut expected = [0; K];
-        for i in 0..K {
-            expected[i] = (i as u128) + 1;
-        }
-        assert_eq!(expected, arr);
-    }
-
-    // test parallel prefix sum algorithm
+    // test parallel prefix sum algorithm with a large set of random data
     #[test]
     fn test_parallel_prefix_sum() {
         // generate some random data
@@ -163,7 +156,7 @@ mod tests {
 
         // time parallel algorithm
         let start_par = Instant::now();
-        parallel_prefix_sum::<u128>(&mut par[..]);
+        parallel_prefix_sum(&mut par[..]);
         let dur_par = start_par.elapsed();
 
         // time sequential algorithm
@@ -178,5 +171,68 @@ mod tests {
 
         // print results
         println!("parallel = {:?}, sequential = {:?}", dur_par, dur_seq);
+    }
+
+    const K: usize = 100;
+    // test a fully sequential version of parallel prefix sum
+    #[test]
+    fn test_parallel_prefix_sum_full_seq() {
+        let mut arr = [1usize; K];
+        parallel_prefix_sum_tune(&mut arr, 1, usize::MAX);
+        let mut expected = [0; K];
+        for i in 0..K {
+            expected[i] = i + 1;
+        }
+        assert_eq!(expected, arr);
+    }
+
+    // test a fully parallel version of parallel prefix sum
+    #[test]
+    fn test_parallel_prefix_sum_full_par() {
+        let mut arr = [1usize; K];
+        parallel_prefix_sum_tune(&mut arr, usize::MAX, 1);
+        let mut expected = [0; K];
+        for i in 0..K {
+            expected[i] = i + 1;
+        }
+        assert_eq!(expected, arr);
+    }
+
+    // tests to ensure parallel prefix panics if given bad tuning args
+    #[test]
+    #[should_panic]
+    fn test_parallel_prefix_sum_bad_args_1() {
+        let mut arr = [0; 0];
+        parallel_prefix_sum_tune(&mut arr, 0, 1);
+    }
+    #[test]
+    #[should_panic]
+    fn test_parallel_prefix_sum_bad_args_2() {
+        let mut arr = [0; 0];
+        parallel_prefix_sum_tune(&mut arr, 0, 0);
+    }
+    #[test]
+    #[should_panic]
+    fn test_parallel_prefix_sum_bad_args_3() {
+        let mut arr = [0; 0];
+        parallel_prefix_sum_tune(&mut arr, 1, 0);
+    }
+
+    const J: usize = 20;
+    // test with product operator
+    #[test]
+    fn test_parallel_prefix_product() {
+        let mut arr = [2usize; J];
+        let accumulate_fn = &|a: &mut usize, b: &usize| {
+            *a *= b;
+        };
+        parallel_prefix_tune(&mut arr, accumulate_fn, 10, 2);
+        let mut expected = [0; J];
+        let mut product = 1;
+        for i in 0..J {
+            product *= 2;
+            expected[i] = product;
+        }
+        assert_eq!(expected, arr);
     }
 }


### PR DESCRIPTION
changed code in lib.rs from
```
mod pack;
mod prefix;
```
to
```
pub mod pack;
pub mod prefix;
```
so that users of the library can access these modules.

changed `cores` to `threads` and `threshold` to `seq_threshold`, these are more accurate names for these parameters.

`parallel_prefix_tune` now panics if `threads` or `seq_threshold` are 0, I believe this is better than silently changing each to 1.

added test cases to check for panicking behavior and other correctness tests.